### PR TITLE
Fix visibility filter in ProduitSitemap: update field name from 'est_…

### DIFF
--- a/src/administration/sitemaps.py
+++ b/src/administration/sitemaps.py
@@ -44,7 +44,7 @@ class ProduitSitemap(Sitemap):
 
     def items(self):
         # Retourne tous les produits visibles
-        return Produit.objects.filter(est_visible=True)
+        return Produit.objects.filter(is_visible=True)
     
     def lastmod(self, obj):
         # Date de dernière modification


### PR DESCRIPTION
…visible' to 'is_visible' for correct product visibility retrieval.